### PR TITLE
Make all parameters of `ErrorException` constructor required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enh #163: Explicitly import classes, functions, and constants in "use" section (@mspirkov)
 - Bug #164: Fix missing items in stack trace HTML output when handling a PHP error (@vjik)
 - Bug #166: Fix broken link to error handling guide (@vjik)
+- Chg #170: Make all parameters of `ErrorException` constructor required (@vjik)
 
 ## 4.3.2 January 09, 2026
 

--- a/src/Exception/ErrorException.php
+++ b/src/Exception/ErrorException.php
@@ -56,8 +56,15 @@ class ErrorException extends \ErrorException implements FriendlyExceptionInterfa
     ];
 
     /** @psalm-param DebugBacktraceType $backtrace */
-    public function __construct(string $message = '', int $code = 0, int $severity = 1, string $filename = __FILE__, int $line = __LINE__, ?Exception $previous = null, private readonly array $backtrace = [])
-    {
+    public function __construct(
+        string $message,
+        int $code,
+        int $severity,
+        string $filename,
+        int $line,
+        ?Exception $previous,
+        private readonly array $backtrace,
+    ) {
         parent::__construct($message, $code, $severity, $filename, $line, $previous);
         $this->addXDebugTraceToFatalIfAvailable();
     }

--- a/tests/Renderer/HtmlRendererTest.php
+++ b/tests/Renderer/HtmlRendererTest.php
@@ -423,7 +423,15 @@ final class HtmlRendererTest extends TestCase
         $renderer = new HtmlRenderer();
 
         $result = $renderer->renderCallStack(
-            new ErrorException('test-message'),
+            new ErrorException(
+                'test-message',
+                0,
+                0,
+                __FILE__,
+                __LINE__,
+                null,
+                [],
+            ),
             TestHelper::generateTrace([true, true, false, true]),
         );
 
@@ -455,8 +463,18 @@ final class HtmlRendererTest extends TestCase
 
     public function testGetThrowableName(): void
     {
+        $exception = new ErrorException(
+            'test-message',
+            0,
+            0,
+            __FILE__,
+            __LINE__,
+            null,
+            [],
+        );
+
         $renderer = new HtmlRenderer();
-        $name = $renderer->getThrowableName(new ErrorException());
+        $name = $renderer->getThrowableName($exception);
 
         $this->assertSame('Error (' . ErrorException::class . ')', $name);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

