### PR TITLE
Fix #106: Improve closure rendering in stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Enh #163: Explicitly import classes, functions, and constants in "use" section (@mspirkov)
 - Bug #164: Fix missing items in stack trace HTML output when handling a PHP error (@vjik)
 - Bug #166: Fix broken link to error handling guide (@vjik)
-- Bug #172: Fix closure rendering in stack traces and keep items when source is unavailable (@WarLikeLaux)
+- Enh #172: Improve closure rendering in stack traces (@WarLikeLaux)
+- Bug #172: Keep items in stack traces when source is unavailable (@WarLikeLaux)
 
 ## 4.3.2 January 09, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enh #163: Explicitly import classes, functions, and constants in "use" section (@mspirkov)
 - Bug #164: Fix missing items in stack trace HTML output when handling a PHP error (@vjik)
 - Bug #166: Fix broken link to error handling guide (@vjik)
+- Enh #172: Improve closure rendering in stack traces and keep items when source is unavailable (@WarLikeLaux)
 
 ## 4.3.2 January 09, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Enh #163: Explicitly import classes, functions, and constants in "use" section (@mspirkov)
 - Bug #164: Fix missing items in stack trace HTML output when handling a PHP error (@vjik)
 - Bug #166: Fix broken link to error handling guide (@vjik)
-- Enh #172: Improve closure rendering in stack traces and keep items when source is unavailable (@WarLikeLaux)
+- Bug #172: Fix closure rendering in stack traces and keep items when source is unavailable (@WarLikeLaux)
 
 ## 4.3.2 January 09, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - New #171: Add `$traceFileMap` parameter to `HtmlRenderer` for mapping file paths in trace links (@WarLikeLaux)
 - Enh #172: Improve closure rendering in stack traces (@WarLikeLaux)
 - Bug #172: Keep items in stack traces when source is unavailable (@WarLikeLaux)
+- Bug #172: Don't render non-positive line number in stack trace frame (@WarLikeLaux)
 
 ## 4.3.2 January 09, 2026
 

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -355,7 +355,7 @@ final class HtmlRenderer implements ThrowableRendererInterface
             $function = null;
             if (!empty($traceItem['function']) && $traceItem['function'] !== 'unknown') {
                 $function = $traceItem['function'];
-                if (!str_contains($function, '{closure}')) {
+                if (!str_contains($function, '{closure')) {
                     try {
                         if ($class !== null && class_exists($class)) {
                             $parameters = (new ReflectionMethod($class, $function))->getParameters();
@@ -566,6 +566,34 @@ final class HtmlRenderer implements ThrowableRendererInterface
     }
 
     /**
+     * Formats a trace function name for display.
+     *
+     * Handles PHP 8.4+ closure format `{closure:Context:line}` by extracting the definition context.
+     * For regular functions, prepends the class name when available.
+     */
+    public function formatTraceFunctionName(?string $class, string $function): string
+    {
+        // PHP 8.4+: {closure:Context:line} - already contains full definition context.
+        if (preg_match('/^\{closure:(.+):(\d+)\}$/', $function, $matches)) {
+            return '{closure} ' . $matches[1] . ':' . $matches[2];
+        }
+
+        // PHP < 8.4 namespaced closure: Namespace\{closure} - strip redundant namespace.
+        if (str_contains($function, '\\{closure')) {
+            if ($class !== null && $class !== 'Closure') {
+                return $this->removeAnonymous($class) . '::{closure}';
+            }
+            return $function;
+        }
+
+        if ($class === null || $class === 'Closure') {
+            return $function;
+        }
+
+        return $this->removeAnonymous($class) . '::' . $function;
+    }
+
+    /**
      * Extracts a user-facing description from throwable class PHPDoc.
      *
      * Takes only descriptive text before block tags, normalizes unsafe markup
@@ -740,12 +768,13 @@ final class HtmlRenderer implements ThrowableRendererInterface
         if ($file !== null && $line !== null) {
             $line--; // adjust line number from one-based to zero-based
             $lines = @file($file);
-            if ($line < 0 || $lines === false || ($lineCount = count($lines)) < $line) {
-                return '';
+            if ($line >= 0 && $lines !== false && ($lineCount = count($lines)) > $line) {
+                $half = (int) (($index === 1 ? $this->maxSourceLines : $this->maxTraceLines) / 2);
+                $begin = $line - $half > 0 ? $line - $half : 0;
+                $end = $line + $half < $lineCount ? $line + $half : $lineCount - 1;
+            } else {
+                $lines = [];
             }
-            $half = (int) (($index === 1 ? $this->maxSourceLines : $this->maxTraceLines) / 2);
-            $begin = $line - $half > 0 ? $line - $half : 0;
-            $end = $line + $half < $lineCount ? $line + $half : $lineCount - 1;
         }
 
         return $this->renderTemplate($this->defaultTemplatePath . '/_call-stack-item.php', [

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -768,12 +768,17 @@ final class HtmlRenderer implements ThrowableRendererInterface
         if ($file !== null && $line !== null) {
             $line--; // adjust line number from one-based to zero-based
             $lines = @file($file);
-            if ($line >= 0 && $lines !== false && ($lineCount = count($lines)) > $line) {
-                $half = (int) (($index === 1 ? $this->maxSourceLines : $this->maxTraceLines) / 2);
-                $begin = $line - $half > 0 ? $line - $half : 0;
-                $end = $line + $half < $lineCount ? $line + $half : $lineCount - 1;
-            } else {
+            if ($line < 0 || $lines === false) {
                 $lines = [];
+            } else {
+                $lineCount = count($lines);
+                if ($line < $lineCount) {
+                    $half = (int) (($index === 1 ? $this->maxSourceLines : $this->maxTraceLines) / 2);
+                    $begin = $line - $half > 0 ? $line - $half : 0;
+                    $end = $line + $half < $lineCount ? $line + $half : $lineCount - 1;
+                } else {
+                    $lines = [];
+                }
             }
         }
 

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -774,6 +774,9 @@ final class HtmlRenderer implements ThrowableRendererInterface
             $line--; // adjust line number from one-based to zero-based
             $lines = @file($file);
             if ($line < 0 || $lines === false) {
+                if ($line < 0) {
+                    $line = null; // non-positive line has no valid source location to show
+                }
                 $lines = [];
             } else {
                 $lineCount = count($lines);

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -777,7 +777,7 @@ final class HtmlRenderer implements ThrowableRendererInterface
                 $lines = [];
             } else {
                 $lineCount = count($lines);
-                if ($line < $lineCount) {
+                if ($line <= $lineCount) {
                     $half = (int) (($index === 1 ? $this->maxSourceLines : $this->maxTraceLines) / 2);
                     $begin = $line - $half > 0 ? $line - $half : 0;
                     $end = $line + $half < $lineCount ? $line + $half : $lineCount - 1;

--- a/templates/_call-stack-item.php
+++ b/templates/_call-stack-item.php
@@ -62,7 +62,7 @@ HTML;
                 <span class="function-info word-break">
                     <?php
                     echo $file === null ? "$index. " : '&mdash;&nbsp;';
-                    $function = $class === null ? $function : "{$this->removeAnonymous($class)}::$function";
+                    $function = $this->formatTraceFunctionName($class, $function);
 
                     echo '<span class="function">' . $this->htmlEncode($function) . '</span>';
                     echo '<span class="arguments">(';

--- a/tests/Renderer/HtmlRendererTest.php
+++ b/tests/Renderer/HtmlRendererTest.php
@@ -809,7 +809,7 @@ final class HtmlRendererTest extends TestCase
         $result = $renderer->renderCallStack($exception, $exception->getTrace());
 
         $this->assertMatchesRegularExpression(
-            '#\{closure\}\s+.+/tests/Support/file_level_closure_exception\.php:\d+#',
+            '#\{closure\}\s+.+[/\\\\]tests[/\\\\]Support[/\\\\]file_level_closure_exception\.php:\d+#',
             $result,
         );
     }

--- a/tests/Renderer/HtmlRendererTest.php
+++ b/tests/Renderer/HtmlRendererTest.php
@@ -631,6 +631,47 @@ final class HtmlRendererTest extends TestCase
         $this->assertSame($expected, $link);
     }
 
+    public static function dataFormatTraceFunctionName(): iterable
+    {
+        yield 'regular function without class' => [
+            null, 'array_map', 'array_map',
+        ];
+        yield 'regular method' => [
+            'Foo', 'bar', 'Foo::bar',
+        ];
+        yield 'old closure without class' => [
+            null, '{closure}', '{closure}',
+        ];
+        yield 'old closure with class' => [
+            'Foo', '{closure}', 'Foo::{closure}',
+        ];
+        yield 'bound closure' => [
+            'Closure', '{closure}', '{closure}',
+        ];
+        yield 'namespaced closure with class' => [
+            'Yiisoft\\Yii\\Gii\\Gii', 'Yiisoft\\Yii\\Gii\\{closure}', 'Yiisoft\\Yii\\Gii\\Gii::{closure}',
+        ];
+        yield 'namespaced closure without class' => [
+            null, 'Yiisoft\\Yii\\Gii\\{closure}', 'Yiisoft\\Yii\\Gii\\{closure}',
+        ];
+        yield 'php84 closure in method' => [
+            'Foo', '{closure:Foo::bar():4}', '{closure} Foo::bar():4',
+        ];
+        yield 'php84 closure in file' => [
+            null, '{closure:/app/src/index.php:12}', '{closure} /app/src/index.php:12',
+        ];
+        yield 'php84 nested closure' => [
+            null, '{closure:{closure:/app/index.php:5}:8}', '{closure} {closure:/app/index.php:5}:8',
+        ];
+    }
+
+    #[DataProvider('dataFormatTraceFunctionName')]
+    public function testFormatTraceFunctionName(?string $class, string $function, string $expected): void
+    {
+        $renderer = new HtmlRenderer();
+        $this->assertSame($expected, $renderer->formatTraceFunctionName($class, $function));
+    }
+
     public function testRenderCallStackWithMethodClosure(): void
     {
         $renderer = new HtmlRenderer();

--- a/tests/Renderer/HtmlRendererTest.php
+++ b/tests/Renderer/HtmlRendererTest.php
@@ -452,6 +452,25 @@ final class HtmlRendererTest extends TestCase
         $this->assertStringNotContainsString('element-code-wrap', $result);
     }
 
+    public function testRenderCallStackItemRendersSourceCodeForLastLineInFile(): void
+    {
+        $line = count(file(__FILE__));
+        $result = $this->invokeMethod(new HtmlRenderer(), 'renderCallStackItem', [
+            'file' => __FILE__,
+            'line' => $line,
+            'class' => null,
+            'function' => null,
+            'args' => [],
+            'index' => 1,
+            'isVendorFile' => false,
+            'reflectionParameters' => [],
+        ]);
+
+        $this->assertStringContainsString(__FILE__, $result);
+        $this->assertStringContainsString('at line ' . $line, $result);
+        $this->assertStringContainsString('element-code-wrap', $result);
+    }
+
     public function testRenderRequest(): void
     {
         $renderer = new HtmlRenderer();
@@ -669,7 +688,7 @@ final class HtmlRendererTest extends TestCase
     public function testFormatTraceFunctionName(?string $class, string $function, string $expected): void
     {
         $renderer = new HtmlRenderer();
-        $this->assertSame($expected, $renderer->formatTraceFunctionName($class, $function));
+        $this->assertSame($expected, $this->invokeMethod($renderer, 'formatTraceFunctionName', [$class, $function]));
     }
 
     public function testRenderCallStackWithMethodClosure(): void
@@ -684,9 +703,6 @@ final class HtmlRendererTest extends TestCase
         $this->assertStringContainsString('{closure', $traceItem['function']);
 
         $result = $renderer->renderCallStack($exception, $exception->getTrace());
-
-        $this->assertStringContainsString('{closure}', $result);
-        $this->assertStringNotContainsString(self::class . '::' . $traceItem['function'], $result);
 
         if (PHP_VERSION_ID >= 80400) {
             $this->assertMatchesRegularExpression(
@@ -720,10 +736,6 @@ final class HtmlRendererTest extends TestCase
             [],
         ]);
 
-        $this->assertStringContainsString('{closure}', $result);
-        $this->assertStringContainsString('{closure}', $itemResult);
-        $this->assertStringNotContainsString('Closure::{closure}', $itemResult);
-
         if (PHP_VERSION_ID >= 80400) {
             $this->assertMatchesRegularExpression('/\{closure\}\s+.+::createBoundClosureException\(\):\d+/', $result);
             return;
@@ -755,9 +767,6 @@ final class HtmlRendererTest extends TestCase
             [],
         ]);
 
-        $this->assertStringContainsString('{closure}', $result);
-        $this->assertStringNotContainsString(self::class . '::' . $traceItem['function'], $result);
-        $this->assertStringContainsString('{closure}', $itemResult);
         $this->assertStringNotContainsString('element-code-wrap', $itemResult);
 
         if (PHP_VERSION_ID >= 80400) {
@@ -804,7 +813,6 @@ final class HtmlRendererTest extends TestCase
         $traceItem = $exception->getTrace()[0];
 
         $this->assertArrayNotHasKey('class', $traceItem);
-        $this->assertStringContainsString('{closure:', $traceItem['function']);
 
         $result = $renderer->renderCallStack($exception, $exception->getTrace());
 
@@ -866,8 +874,7 @@ final class HtmlRendererTest extends TestCase
             return $e;
         }
 
-        $this->fail('Expected exception from method closure.');
-        throw new RuntimeException('Unreachable.');
+        $this->fail('Method closure did not throw RuntimeException.');
     }
 
     private function createInternalFunctionClosureException(): RuntimeException
@@ -882,8 +889,7 @@ final class HtmlRendererTest extends TestCase
             return $e;
         }
 
-        $this->fail('Expected exception from closure called via internal function.');
-        throw new RuntimeException('Unreachable.');
+        $this->fail('Closure called via internal function did not throw RuntimeException.');
     }
 
     private function createBoundClosureException(): RuntimeException
@@ -901,8 +907,7 @@ final class HtmlRendererTest extends TestCase
             return $e;
         }
 
-        $this->fail('Expected exception from Closure scope closure.');
-        throw new RuntimeException('Unreachable.');
+        $this->fail('Bound closure did not throw RuntimeException.');
     }
 
     private function createTestTemplate(string $path, string $templateContents): void

--- a/tests/Renderer/HtmlRendererTest.php
+++ b/tests/Renderer/HtmlRendererTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use Closure;
 use ReflectionClass;
 use ReflectionObject;
 use RuntimeException;
@@ -22,35 +23,41 @@ use Yiisoft\ErrorHandler\Tests\Support\TestExceptionWithoutDocBlock;
 use Yiisoft\ErrorHandler\Tests\Support\TestHelper;
 use Yiisoft\ErrorHandler\Tests\Support\TestInlineCodeDocBlockException;
 use Yiisoft\ErrorHandler\Tests\Support\TestLeadingMarkdownLinkDocBlockException;
+use Yiisoft\ErrorHandler\Tests\Support\NamespacedClosureTraceFixture;
 use Yiisoft\ErrorHandler\Tests\Support\TestOwaspFilterEvasionDocBlockException;
 use Yiisoft\ErrorHandler\Tests\Support\TestParenthesizedMarkdownDocBlockException;
 use Yiisoft\ErrorHandler\Tests\Support\TestQueryStringDocBlockException;
 use Yiisoft\ErrorHandler\Tests\Support\TestUnsafeDocBlockException;
 use Yiisoft\ErrorHandler\Tests\Support\TestUnsafeMarkdownDocBlockException;
+use stdClass;
 
 use function dirname;
 use function file_exists;
 use function file_put_contents;
 use function fopen;
+use function Yiisoft\ErrorHandler\Tests\Support\loadFileLevelClosureException;
 use function unlink;
 use function sprintf;
+use function count;
 
 use const DIRECTORY_SEPARATOR;
+use const PHP_VERSION_ID;
+
+require_once dirname(__DIR__) . '/Support/FileLevelClosureLoader.php';
 
 final class HtmlRendererTest extends TestCase
 {
-    private const CUSTOM_SETTING = [
-        'verboseTemplate' => __DIR__ . '/test-template-verbose.php',
-        'template' => __DIR__ . '/test-template-non-verbose.php',
-    ];
+    private array $temporaryFiles = [];
 
     protected function tearDown(): void
     {
-        foreach (self::CUSTOM_SETTING as $template) {
+        foreach ($this->temporaryFiles as $template) {
             if (file_exists($template)) {
                 unlink($template);
             }
         }
+
+        $this->temporaryFiles = [];
     }
 
     public function testNonVerboseOutput(): void
@@ -312,10 +319,11 @@ final class HtmlRendererTest extends TestCase
 
     public function testNonVerboseOutputWithCustomTemplate(): void
     {
+        $settings = $this->createCustomSetting();
         $templateFileContents = '<html><?php echo $throwable->getMessage();?></html>';
-        $this->createTestTemplate(self::CUSTOM_SETTING['template'], $templateFileContents);
+        $this->createTestTemplate($settings['template'], $templateFileContents);
 
-        $renderer = new HtmlRenderer(self::CUSTOM_SETTING);
+        $renderer = new HtmlRenderer($settings);
         $exceptionMessage = 'exception-test-message';
         $exception = new RuntimeException($exceptionMessage);
 
@@ -325,10 +333,11 @@ final class HtmlRendererTest extends TestCase
 
     public function testVerboseOutputWithCustomTemplate(): void
     {
+        $settings = $this->createCustomSetting();
         $templateFileContents = '<html><?php echo $throwable->getMessage();?></html>';
-        $this->createTestTemplate(self::CUSTOM_SETTING['verboseTemplate'], $templateFileContents);
+        $this->createTestTemplate($settings['verboseTemplate'], $templateFileContents);
 
-        $renderer = new HtmlRenderer(self::CUSTOM_SETTING);
+        $renderer = new HtmlRenderer($settings);
         $exceptionMessage = 'exception-test-message';
         $exception = new RuntimeException($exceptionMessage);
 
@@ -347,8 +356,9 @@ final class HtmlRendererTest extends TestCase
 
     public function testRenderTemplateThrowsExceptionWhenFailureInTemplate(): void
     {
-        $this->createTestTemplate(self::CUSTOM_SETTING['verboseTemplate'], '<html><?php throw $throwable;?></html>');
-        $renderer = new HtmlRenderer(self::CUSTOM_SETTING);
+        $settings = $this->createCustomSetting();
+        $this->createTestTemplate($settings['verboseTemplate'], '<html><?php throw $throwable;?></html>');
+        $renderer = new HtmlRenderer($settings);
         $exceptionMessage = 'Template error.';
         $exception = new RuntimeException($exceptionMessage);
 
@@ -359,11 +369,12 @@ final class HtmlRendererTest extends TestCase
 
     public function testRenderPreviousExceptions(): void
     {
+        $settings = $this->createCustomSetting();
         $previousExceptionMessage = 'Test Previous Exception.';
         $exception = new RuntimeException('Some error.', 0, new Exception($previousExceptionMessage));
         $templateFileContents = '<?php echo $this->renderPreviousExceptions($throwable); ?>';
-        $this->createTestTemplate(self::CUSTOM_SETTING['verboseTemplate'], $templateFileContents);
-        $renderer = new HtmlRenderer(self::CUSTOM_SETTING);
+        $this->createTestTemplate($settings['verboseTemplate'], $templateFileContents);
+        $renderer = new HtmlRenderer($settings);
 
         $errorData = $renderer->renderVerbose($exception, $this->createServerRequestMock());
         $this->assertStringContainsString($previousExceptionMessage, (string) $errorData);
@@ -371,7 +382,7 @@ final class HtmlRendererTest extends TestCase
 
     public function testRenderCallStack(): void
     {
-        $renderer = new HtmlRenderer(self::CUSTOM_SETTING);
+        $renderer = new HtmlRenderer();
         $this->setVendorPaths($renderer, [dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor']);
 
         $this->assertStringContainsString(
@@ -401,7 +412,8 @@ final class HtmlRendererTest extends TestCase
         ]);
         restore_error_handler();
 
-        $this->assertSame('', $result);
+        $this->assertStringContainsString('not-exist', $result);
+        $this->assertStringContainsString('call-stack-item', $result);
         $this->assertSame('file(not-exist): Failed to open stream: No such file or directory', $errorMessage);
     }
 
@@ -419,6 +431,25 @@ final class HtmlRendererTest extends TestCase
         $this->assertStringContainsString('3. ', $result);
         $this->assertStringContainsString('4. ', $result);
         $this->assertStringContainsString('5. ', $result);
+    }
+
+    public function testRenderCallStackItemDoesNotRenderSourceCodeWhenLineIsOutsideFileRange(): void
+    {
+        $line = count(file(__FILE__)) + 1;
+        $result = $this->invokeMethod(new HtmlRenderer(), 'renderCallStackItem', [
+            'file' => __FILE__,
+            'line' => $line,
+            'class' => null,
+            'function' => null,
+            'args' => [],
+            'index' => 1,
+            'isVendorFile' => false,
+            'reflectionParameters' => [],
+        ]);
+
+        $this->assertStringContainsString(__FILE__, $result);
+        $this->assertStringContainsString('at line ' . $line, $result);
+        $this->assertStringNotContainsString('element-code-wrap', $result);
     }
 
     public function testRenderRequest(): void
@@ -600,6 +631,148 @@ final class HtmlRendererTest extends TestCase
         $this->assertSame($expected, $link);
     }
 
+    public function testRenderCallStackWithMethodClosure(): void
+    {
+        $renderer = new HtmlRenderer();
+        $exception = $this->createMethodClosureException();
+        $traceItem = $exception->getTrace()[0];
+
+        $this->assertArrayHasKey('file', $traceItem);
+        $this->assertArrayHasKey('line', $traceItem);
+        $this->assertSame(self::class, $traceItem['class']);
+        $this->assertStringContainsString('{closure', $traceItem['function']);
+
+        $result = $renderer->renderCallStack($exception, $exception->getTrace());
+
+        $this->assertStringContainsString('{closure}', $result);
+        $this->assertStringNotContainsString(self::class . '::' . $traceItem['function'], $result);
+
+        if (PHP_VERSION_ID >= 80400) {
+            $this->assertMatchesRegularExpression(
+                '/\{closure\}\s+' . preg_quote(self::class, '/') . '::createMethodClosureException\(\):\d+/',
+                $result,
+            );
+            return;
+        }
+
+        $this->assertStringContainsString(self::class . '::{closure}', $result);
+    }
+
+    public function testRenderCallStackWithBoundClosure(): void
+    {
+        $renderer = new HtmlRenderer();
+        $exception = $this->createBoundClosureException();
+        $traceItem = $exception->getTrace()[0];
+
+        $this->assertSame('Closure', $traceItem['class']);
+        $this->assertStringContainsString('{closure', $traceItem['function']);
+
+        $result = $renderer->renderCallStack($exception, $exception->getTrace());
+        $itemResult = $this->invokeMethod($renderer, 'renderCallStackItem', [
+            $traceItem['file'] ?? null,
+            $traceItem['line'] ?? null,
+            $traceItem['class'] ?? null,
+            $traceItem['function'] ?? null,
+            $traceItem['args'] ?? [],
+            2,
+            false,
+            [],
+        ]);
+
+        $this->assertStringContainsString('{closure}', $result);
+        $this->assertStringContainsString('{closure}', $itemResult);
+        $this->assertStringNotContainsString('Closure::{closure}', $itemResult);
+
+        if (PHP_VERSION_ID >= 80400) {
+            $this->assertMatchesRegularExpression('/\{closure\}\s+.+::createBoundClosureException\(\):\d+/', $result);
+            return;
+        }
+
+        $this->assertStringContainsString('Yiisoft\\ErrorHandler\\Tests\\Renderer\\{closure}', $itemResult);
+    }
+
+    public function testRenderCallStackWithInternalFunctionClosure(): void
+    {
+        $renderer = new HtmlRenderer();
+        $exception = $this->createInternalFunctionClosureException();
+        $traceItem = $exception->getTrace()[0];
+
+        $this->assertArrayNotHasKey('file', $traceItem);
+        $this->assertArrayNotHasKey('line', $traceItem);
+        $this->assertSame(self::class, $traceItem['class']);
+        $this->assertStringContainsString('{closure', $traceItem['function']);
+
+        $result = $renderer->renderCallStack($exception, $exception->getTrace());
+        $itemResult = $this->invokeMethod($renderer, 'renderCallStackItem', [
+            $traceItem['file'] ?? null,
+            $traceItem['line'] ?? null,
+            $traceItem['class'] ?? null,
+            $traceItem['function'] ?? null,
+            $traceItem['args'] ?? [],
+            2,
+            false,
+            [],
+        ]);
+
+        $this->assertStringContainsString('{closure}', $result);
+        $this->assertStringNotContainsString(self::class . '::' . $traceItem['function'], $result);
+        $this->assertStringContainsString('{closure}', $itemResult);
+        $this->assertStringNotContainsString('element-code-wrap', $itemResult);
+
+        if (PHP_VERSION_ID >= 80400) {
+            $this->assertMatchesRegularExpression(
+                '/\{closure\}\s+' . preg_quote(self::class, '/') . '::createInternalFunctionClosureException\(\):\d+/',
+                $result,
+            );
+            return;
+        }
+
+        $this->assertStringContainsString(self::class . '::{closure}', $result);
+    }
+
+    public function testRenderCallStackWithNamespacedClosureOnPhpBelow84(): void
+    {
+        if (PHP_VERSION_ID >= 80400) {
+            $this->markTestSkipped('PHP < 8.4 specific behavior.');
+        }
+
+        $renderer = new HtmlRenderer();
+        $exception = NamespacedClosureTraceFixture::createException();
+        $traceItem = $exception->getTrace()[0];
+
+        $this->assertSame(NamespacedClosureTraceFixture::class, $traceItem['class']);
+        $this->assertSame('Yiisoft\\ErrorHandler\\Tests\\Support\\{closure}', $traceItem['function']);
+
+        $result = $renderer->renderCallStack($exception, $exception->getTrace());
+
+        $this->assertStringContainsString(NamespacedClosureTraceFixture::class . '::{closure}', $result);
+        $this->assertStringNotContainsString(
+            NamespacedClosureTraceFixture::class . '::' . $traceItem['function'],
+            $result,
+        );
+    }
+
+    public function testRenderCallStackWithFileLevelClosureOnPhp84Plus(): void
+    {
+        if (PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('PHP 8.4+ specific behavior.');
+        }
+
+        $renderer = new HtmlRenderer();
+        $exception = loadFileLevelClosureException();
+        $traceItem = $exception->getTrace()[0];
+
+        $this->assertArrayNotHasKey('class', $traceItem);
+        $this->assertStringContainsString('{closure:', $traceItem['function']);
+
+        $result = $renderer->renderCallStack($exception, $exception->getTrace());
+
+        $this->assertMatchesRegularExpression(
+            '#\{closure\}\s+.+/tests/Support/file_level_closure_exception\.php:\d+#',
+            $result,
+        );
+    }
+
     private function createServerRequestMock(): ServerRequestInterface
     {
         $serverRequestMock = $this->createMock(ServerRequestInterface::class);
@@ -640,11 +813,80 @@ final class HtmlRendererTest extends TestCase
         return $serverRequestMock;
     }
 
+    private function createMethodClosureException(): RuntimeException
+    {
+        $closure = function (): void {
+            throw new RuntimeException('test');
+        };
+
+        try {
+            $closure();
+        } catch (RuntimeException $e) {
+            return $e;
+        }
+
+        $this->fail('Expected exception from method closure.');
+        throw new RuntimeException('Unreachable.');
+    }
+
+    private function createInternalFunctionClosureException(): RuntimeException
+    {
+        $closure = function (int $value): void {
+            throw new RuntimeException((string) $value);
+        };
+
+        try {
+            array_map($closure, [1]);
+        } catch (RuntimeException $e) {
+            return $e;
+        }
+
+        $this->fail('Expected exception from closure called via internal function.');
+        throw new RuntimeException('Unreachable.');
+    }
+
+    private function createBoundClosureException(): RuntimeException
+    {
+        $closure = function (): void {
+            throw new RuntimeException('test');
+        };
+
+        $boundClosure = Closure::bind($closure, new stdClass(), null);
+        $this->assertInstanceOf(Closure::class, $boundClosure);
+
+        try {
+            $boundClosure();
+        } catch (RuntimeException $e) {
+            return $e;
+        }
+
+        $this->fail('Expected exception from Closure scope closure.');
+        throw new RuntimeException('Unreachable.');
+    }
+
     private function createTestTemplate(string $path, string $templateContents): void
     {
         if (!file_put_contents($path, $templateContents)) {
             throw new RuntimeException(sprintf('Unable to create file at path %s', $path));
         }
+    }
+
+    private function createCustomSetting(): array
+    {
+        $verboseTemplate = tempnam(sys_get_temp_dir(), 'verbose-template-');
+        $template = tempnam(sys_get_temp_dir(), 'template-');
+
+        if ($verboseTemplate === false || $template === false) {
+            throw new RuntimeException('Unable to create temporary template paths.');
+        }
+
+        $this->temporaryFiles[] = $verboseTemplate;
+        $this->temporaryFiles[] = $template;
+
+        return [
+            'verboseTemplate' => $verboseTemplate,
+            'template' => $template,
+        ];
     }
 
     private function invokeMethod(object $object, string $method, array $args = [])

--- a/tests/Renderer/HtmlRendererTest.php
+++ b/tests/Renderer/HtmlRendererTest.php
@@ -443,7 +443,8 @@ final class HtmlRendererTest extends TestCase
 
     public function testRenderCallStackItemDoesNotRenderSourceCodeWhenLineIsOutsideFileRange(): void
     {
-        $line = count(file(__FILE__)) + 1;
+        // +2 because the renderer tolerates one line past EOF, so the line must be clearly out of range.
+        $line = count(file(__FILE__)) + 2;
         $result = $this->invokeMethod(new HtmlRenderer(), 'renderCallStackItem', [
             'file' => __FILE__,
             'line' => $line,

--- a/tests/Renderer/HtmlRendererTest.php
+++ b/tests/Renderer/HtmlRendererTest.php
@@ -510,6 +510,23 @@ final class HtmlRendererTest extends TestCase
         $this->assertStringContainsString('element-code-wrap', $result);
     }
 
+    public function testRenderCallStackItemRendersNoLineWhenLineIsNotPositive(): void
+    {
+        $result = $this->invokeMethod(new HtmlRenderer(), 'renderCallStackItem', [
+            'file' => __FILE__,
+            'line' => 0,
+            'class' => null,
+            'function' => null,
+            'args' => [],
+            'index' => 1,
+            'isVendorFile' => false,
+            'reflectionParameters' => [],
+        ]);
+
+        $this->assertStringContainsString(__FILE__, $result);
+        $this->assertStringNotContainsString('at line', $result);
+    }
+
     public function testRenderRequest(): void
     {
         $renderer = new HtmlRenderer();

--- a/tests/Renderer/HtmlRendererTest.php
+++ b/tests/Renderer/HtmlRendererTest.php
@@ -31,10 +31,17 @@ use Yiisoft\ErrorHandler\Tests\Support\TestUnsafeDocBlockException;
 use Yiisoft\ErrorHandler\Tests\Support\TestUnsafeMarkdownDocBlockException;
 use stdClass;
 
+use function array_map;
 use function dirname;
+use function file;
 use function file_exists;
 use function file_put_contents;
 use function fopen;
+use function preg_quote;
+use function restore_error_handler;
+use function set_error_handler;
+use function sys_get_temp_dir;
+use function tempnam;
 use function Yiisoft\ErrorHandler\Tests\Support\loadFileLevelClosureException;
 use function unlink;
 use function sprintf;
@@ -414,7 +421,8 @@ final class HtmlRendererTest extends TestCase
 
         $this->assertStringContainsString('not-exist', $result);
         $this->assertStringContainsString('call-stack-item', $result);
-        $this->assertSame('file(not-exist): Failed to open stream: No such file or directory', $errorMessage);
+        $this->assertNotNull($errorMessage);
+        $this->assertStringContainsString('not-exist', $errorMessage);
     }
 
     public function testRenderCallStackWithErrorException(): void

--- a/tests/Renderer/HtmlRendererTest.php
+++ b/tests/Renderer/HtmlRendererTest.php
@@ -37,6 +37,7 @@ use function file;
 use function file_exists;
 use function file_put_contents;
 use function fopen;
+use function preg_match;
 use function preg_quote;
 use function restore_error_handler;
 use function set_error_handler;

--- a/tests/Renderer/HtmlRendererTest.php
+++ b/tests/Renderer/HtmlRendererTest.php
@@ -489,6 +489,27 @@ final class HtmlRendererTest extends TestCase
         $this->assertStringContainsString('element-code-wrap', $result);
     }
 
+    public function testRenderCallStackItemRendersSourceCodeWhenLineEqualsLineCount(): void
+    {
+        // `$lineCount === $line` boundary: after the zero-based adjustment the line lands one past
+        // the last valid index, and the renderer still shows the trailing source lines.
+        $line = count(file(__FILE__)) + 1;
+        $result = $this->invokeMethod(new HtmlRenderer(), 'renderCallStackItem', [
+            'file' => __FILE__,
+            'line' => $line,
+            'class' => null,
+            'function' => null,
+            'args' => [],
+            'index' => 1,
+            'isVendorFile' => false,
+            'reflectionParameters' => [],
+        ]);
+
+        $this->assertStringContainsString(__FILE__, $result);
+        $this->assertStringContainsString('at line ' . $line, $result);
+        $this->assertStringContainsString('element-code-wrap', $result);
+    }
+
     public function testRenderRequest(): void
     {
         $renderer = new HtmlRenderer();

--- a/tests/Support/FileLevelClosureLoader.php
+++ b/tests/Support/FileLevelClosureLoader.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\ErrorHandler\Tests\Support;
+
+use RuntimeException;
+
+function loadFileLevelClosureException(): RuntimeException
+{
+    /** @var RuntimeException $exception */
+    $exception = require __DIR__ . '/file_level_closure_exception.php';
+
+    return $exception;
+}

--- a/tests/Support/NamespacedClosureTraceFixture.php
+++ b/tests/Support/NamespacedClosureTraceFixture.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\ErrorHandler\Tests\Support;
+
+use RuntimeException;
+
+final class NamespacedClosureTraceFixture
+{
+    public static function createException(): RuntimeException
+    {
+        $closure = function (): void {
+            throw new RuntimeException('test');
+        };
+
+        try {
+            $closure();
+        } catch (RuntimeException $e) {
+            return $e;
+        }
+
+        throw new RuntimeException('Unreachable.');
+    }
+}

--- a/tests/Support/NamespacedClosureTraceFixture.php
+++ b/tests/Support/NamespacedClosureTraceFixture.php
@@ -20,6 +20,6 @@ final class NamespacedClosureTraceFixture
             return $e;
         }
 
-        throw new RuntimeException('Unreachable.');
+        throw new RuntimeException('Namespaced closure did not throw RuntimeException.');
     }
 }

--- a/tests/Support/file_level_closure_exception.php
+++ b/tests/Support/file_level_closure_exception.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+$closure = function (): void {
+    throw new RuntimeException('test');
+};
+
+try {
+    $closure();
+} catch (RuntimeException $e) {
+    return $e;
+}
+
+throw new RuntimeException('Unreachable.');

--- a/tests/Support/file_level_closure_exception.php
+++ b/tests/Support/file_level_closure_exception.php
@@ -12,4 +12,4 @@ try {
     return $e;
 }
 
-throw new RuntimeException('Unreachable.');
+throw new RuntimeException('File-level closure did not throw RuntimeException.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #106

## What does this PR do?

This fixes how closures are shown in the HTML stack trace and stops some trace items from disappearing.

1. **Keep trace items when the source snippet is unavailable.** `renderCallStackItem()` used to return an empty string when the source file could not be read. That removed the whole item from the error page. Now the item still renders with the available file and function data. The source viewer is skipped.

2. **Remove duplicated namespace parts in closure names.** On PHP < 8.4, a namespaced closure like `Yiisoft\Yii\Gii\{closure}` was combined with the class name and ended up as `Yiisoft\Yii\Gii\Gii::Yiisoft\Yii\Gii\{closure}`. It now renders as `Yiisoft\Yii\Gii\Gii::{closure}`. Bound closures (`class=Closure`) also stop showing the extra `Closure::` prefix.

3. **Format PHP 8.4+ closure names.** PHP 8.4+ uses closure names like `{closure:Foo::bar():4}` that include the definition location. The HTML template now formats that value as `{closure} Foo::bar():4`. `renderCallStack()` also treats both `{closure}` and `{closure:...}` as closure frames.

### Before / After

| Case | Before | After |
|---|---|---|
| Namespaced (PHP < 8.4) | `Ns\Gii::Ns\{closure}` | `Ns\Gii::{closure}` |
| Bound closure | `Closure::{closure}` | `{closure}` |
| PHP 8.4+ in method | `Foo::{closure:Foo::bar():4}` | `{closure} Foo::bar():4` |
| PHP 8.4+ file-level | `{closure:/app/index.php:12}` | `{closure} /app/index.php:12` |
| Simple (PHP < 8.4) | `Foo::{closure}` | `Foo::{closure}` (unchanged) |

### Note on missing file/line

Some closures called through internal PHP functions such as `array_map` do not have `file` or `line` in the trace data. In that case the page shows the function name and arguments only, without a source viewer for that frame. This matches Symfony's error handler, which also renders source excerpts only for frames that have a file path. On PHP 8.4+, the formatted closure name still shows where the closure was defined.

### BC

No BC break: `formatTraceFunctionName()` is a new public helper used by the HTML template.

P.S. Existing tests that use custom templates now create temporary template files per test. This avoids random-order interference between tests and does not change runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved closure rendering in stack traces for better error diagnostics.

* **Bug Fixes**
  * Stack-trace items are now retained when source code is unavailable.

* **Tests**
  * Added comprehensive test coverage for closure and stack-trace rendering across PHP versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->