### PR TITLE
Fix #176: Remove unused `ext-dom` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enh #163: Explicitly import classes, functions, and constants in "use" section (@mspirkov)
 - Bug #164: Fix missing items in stack trace HTML output when handling a PHP error (@vjik)
 - Bug #166: Fix broken link to error handling guide (@vjik)
+- Bug #176: Remove unused `ext-dom` dependency (@samdark)
 - Chg #170: Make all parameters of `ErrorException` constructor required (@vjik)
 - New #171: Add `$traceFileMap` parameter to `HtmlRenderer` for mapping file paths in trace links (@WarLikeLaux)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The package provides advanced error handling. The features are:
 ## Requirements
 
 - PHP 8.1 - 8.5.
-- `DOM` PHP extension.
 - `mbstring` PHP extension.
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     ],
     "require": {
         "php": "8.1 - 8.5",
-        "ext-dom": "*",
         "ext-mbstring": "*",
         "alexkart/curl-builder": "^1.0",
         "cebe/markdown": "^1.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  |

- Remove the unused `ext-dom` runtime requirement.